### PR TITLE
Fix logo display on front page

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -65,8 +65,8 @@ export default function LoginPage() {
   return (
     <div className="container flex h-screen w-screen flex-col items-center justify-center">
       <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
-        <div className="mx-auto w-24 h-24 relative mb-6">
-          <Image src="/logo.png" alt="Acroeduvos Logo" fill className="object-contain" priority />
+        <div className="mx-auto mb-6">
+          <Image src="/logo.png" alt="Acroeduvos Logo" width={96} height={96} priority />
         </div>
 
         <Card>

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -80,8 +80,8 @@ export default function RegisterPage() {
   return (
     <div className="container flex h-screen w-screen flex-col items-center justify-center">
       <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[400px]">
-        <div className="mx-auto w-24 h-24 relative mb-6">
-          <Image src="/logo.png" alt="Acroeduvos Logo" fill className="object-contain" priority />
+        <div className="mx-auto mb-6">
+          <Image src="/logo.png" alt="Acroeduvos Logo" width={96} height={96} priority />
         </div>
 
         <Card>

--- a/app/certificates/[id]/page.tsx
+++ b/app/certificates/[id]/page.tsx
@@ -122,9 +122,7 @@ export default function CertificatePage({ params }: { params: { id: string } }) 
 
           <div className="relative z-10 p-4 text-center">
             <div className="mb-6 flex justify-center">
-              <div className="relative h-24 w-24">
-                <Image src="/logo.png" alt="Acroeduvos Logo" fill className="object-contain" />
-              </div>
+              <Image src="/logo.png" alt="Acroeduvos Logo" width={96} height={96} />
             </div>
 
             <div className="mt-32 mb-8">

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -8,9 +8,7 @@ export function Footer() {
         <div className="grid gap-8 md:grid-cols-4">
           <div>
             <Link href="/" className="flex items-center">
-              <div className="relative h-10 w-10 mr-2">
-                <Image src="/logo.png" alt="Acroeduvos Logo" fill className="object-contain" />
-              </div>
+              <Image src="/logo.png" alt="Acroeduvos Logo" width={40} height={40} className="mr-2" />
               <span className="text-xl font-bold">Acroeduvos</span>
             </Link>
             <p className="mt-2 text-gray-600">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -46,9 +46,7 @@ export function Header() {
     <header className="border-b border-gray-200 bg-white">
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
         <Link href="/" className="flex items-center">
-          <div className="relative h-12 w-12 mr-2">
-            <Image src="/logo.png" alt="Acroeduvos Logo" fill className="object-contain" />
-          </div>
+          <Image src="/logo.png" alt="Acroeduvos Logo" width={48} height={48} className="mr-2" priority />
           <span className="text-xl font-bold hidden sm:inline-block">Acroeduvos</span>
         </Link>
 


### PR DESCRIPTION
Fix invisible logo images by explicitly setting `width` and `height` instead of using `fill`.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfcdc403-9778-4dc2-b93f-2eeb8d152480">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dfcdc403-9778-4dc2-b93f-2eeb8d152480">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

